### PR TITLE
Fix drawer closing when mirroring

### DIFF
--- a/pages/signals.tsx
+++ b/pages/signals.tsx
@@ -72,8 +72,6 @@ const Signals: NextPage = () => {
         type: 'success'
       });
       
-      // Close the drawer if open
-      closeDrawer();
     } catch (error) {
       console.error('Error mirroring trade:', error);
       


### PR DESCRIPTION
## Summary
- keep the signal detail drawer open after mirroring a trade

## Testing
- `npm run test:ci` *(fails: No tests found)*